### PR TITLE
Add cmt* and version requirement bumps

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,5 +1,6 @@
 Dependencies:
 * You need OCaml 4.0 or higher to compile Mlpost.
+* You need Ocamlfind
 * You need the libraries bitstring, lablgtk2 and cairo for cairo support.
   Check the output of ./configure to see if cairo has been selected.
 * To use Mlpost, you need metapost and metafun (packages texlive-metapost and

--- a/INSTALL
+++ b/INSTALL
@@ -1,10 +1,9 @@
 Dependencies:
-* You need Objective Caml 3.08.0 or higher to compile Mlpost.
-* You need Objective Caml 3.10.2 or higher to compile Mlpost with cairo
-  support; You also need the libraries bitstring, lablgtk2 and cairo.
-  check the output of ./configure to see if cairo has been selected.
+* You need OCaml 4.0 or higher to compile Mlpost.
+* You need the libraries bitstring, lablgtk2 and cairo for cairo support.
+  Check the output of ./configure to see if cairo has been selected.
 * To use Mlpost, you need metapost and metafun (packages texlive-metapost and
-  context in debian)
+  context in debian) if you don't use the -mps option.
 * For the html version of the examples, you need caml2html, version 1.3.0 or
   higher.
 * One example needs the tex chess fonts to work (package tex-chess in debian)

--- a/Makefile.in
+++ b/Makefile.in
@@ -24,7 +24,6 @@ datadir = @datadir@
 exec_prefix=@exec_prefix@
 BINDIR=@bindir@
 LIBDIR=@LIBDIR@
-USEOCAMLFIND=@USEOCAMLFIND@
 OCAMLFIND=@OCAMLFIND@
 OCAMLBUILDBIN=@OCAMLBUILD@
 
@@ -103,46 +102,6 @@ install-opt-contrib: install-opt-dot install-opt-lablgtk
 BCMA = $(addprefix $(BUILD), $(CMA) $(DLL))
 BCMXA = $(addprefix $(BUILD), $(CMXA) $(OBJ))
 
-ifeq "@USEOCAMLFIND@" "no"
-install-byte:
-	mkdir -p $(LIBDIR)
-	cp -f $(BUILD)mlpost.cmi META $(BCMA) "$(LIBDIR)"
-
-install-opt:
-	mkdir -p $(LIBDIR)
-	cp -f $(BUILD)mlpost.cmi META $(BCMA) "$(LIBDIR)"
-	cp -f $(BUILD)mlpost$(LIBEXT) $(BCMXA) "$(LIBDIR)"
-
-install-byte-dot:
-	mkdir -p $(LIBDIR)_dot
-	cp -f contrib/dot/META "$(LIBDIR)_dot"
-	cp -f $(addprefix contrib/dot/_build/mlpost_dot,.cmi .cma) "$(LIBDIR)_dot"
-
-install-opt-dot:
-	mkdir -p $(LIBDIR)_dot
-	cp -f contrib/dot/META "$(LIBDIR)_dot"
-	cp -f $(addprefix contrib/dot/_build/mlpost_dot,.cmi .cma .cmxa $(LIBEXT)) "$(LIBDIR)_dot"
-
-ifeq "$(LABLGTK2)$(CAIROLABLGTK2)$(USEOCAMLFIND)" "yesyesyes"
-
-install-byte-lablgtk:
-	mkdir -p $(LIBDIR)_lablgtk
-	cp -f contrib/lablgtk/META "$(LIBDIR)_lablgtk"
-	cp -f $(addprefix contrib/lablgtk/_build/mlpost_lablgtk,.cmi .cma) "$(LIBDIR)_lablgtk"
-
-install-opt-lablgtk:
-	mkdir -p $(LIBDIR)_lablgtk
-	cp -f contrib/lablgtk/META "$(LIBDIR)_lablgtk"
-	cp -f $(addprefix contrib/lablgtk/_build/mlpost_lablgtk,.cmi .cma .cmxa $(LIBEXT)) "$(LIBDIR)_lablgtk"
-
-else
-install-byte-lablgtk:
-
-install-opt-lablgtk:
-
-endif
-
-else
 DESTDIR=-destdir $(LIBDIR:/mlpost=)
 
 install-byte:
@@ -164,7 +123,7 @@ install-opt-dot:
 	$(OCAMLFIND) install $(DESTDIR) mlpost_dot contrib/dot/META \
            $(addprefix contrib/dot/_build/mlpost_dot,.cmi .cma .cmxa $(LIBEXT))
 
-ifeq "$(LABLGTK2)$(CAIROLABLGTK2)$(USEOCAMLFIND)" "yesyesyes"
+ifeq "$(LABLGTK2)$(CAIROLABLGTK2)" "yesyes"
 install-byte-lablgtk:
 	$(OCAMLFIND) remove $(DESTDIR) mlpost_lablgtk
 	$(OCAMLFIND) install $(DESTDIR) mlpost_lablgtk contrib/lablgtk/META \
@@ -181,8 +140,6 @@ install-opt-lablgtk:
 
 endif
 
-endif
-
 install-byte-contrib: install-byte-dot install-byte-lablgtk
 
 
@@ -191,28 +148,14 @@ install-bin:
 	cp -f $(BUILD)$(TOOL) $(BINDIR)/mlpost
 	cp -f mlpost.1 $(MANDIR)/man1
 
-ifeq "@USEOCAMLFIND@" "no"
-uninstall: uninstall-contrib
-	rm -rf $(LIBDIR)
-	rm -f $(BINDIR)/mlpost
-	rm -f $(MANDIR)/mlpost
-else
 uninstall: uninstall-contrib
 	$(OCAMLFIND) remove $(DESTDIR) mlpost
 	rm -f $(BINDIR)/mlpost
 	rm -f $(MANDIR)/mlpost
-endif
 
-ifeq "@USEOCAMLFIND@" "no"
-uninstall-contrib:
-	rm -rf $(LIBDIR)/mlpost_lablgtk
-	rm -rf $(LIBDIR)/mlpost_dot
-else
 uninstall-contrib:
 	$(OCAMLFIND) remove $(DESTDIR) mlpost_dot
 	$(OCAMLFIND) remove $(DESTDIR) mlpost_lablgtk
-endif
-
 
 
 # export

--- a/Makefile.in
+++ b/Makefile.in
@@ -101,38 +101,39 @@ install-opt-contrib: install-opt-dot install-opt-lablgtk
 
 BCMA = $(addprefix $(BUILD), $(CMA) $(DLL))
 BCMXA = $(addprefix $(BUILD), $(CMXA) $(OBJ))
+BCMT = $(addprefix $(BUILD), mlpost.cmti mlpost.cmt)
 
 DESTDIR=-destdir $(LIBDIR:/mlpost=)
 
 install-byte:
 	$(OCAMLFIND) remove $(DESTDIR) mlpost
-	$(OCAMLFIND) install $(DESTDIR) mlpost $(BUILD)mlpost.cmi META $(BCMA)
+	$(OCAMLFIND) install $(DESTDIR) mlpost $(BUILD)mlpost.cmi META $(BCMA) $(BCMT)
 
 install-opt:
 	$(OCAMLFIND) remove $(DESTDIR) mlpost
-	$(OCAMLFIND) install $(DESTDIR) mlpost $(BUILD)mlpost$(LIBEXT) $(BUILD)mlpost.cmi META $(BCMXA) $(BCMA)
+	$(OCAMLFIND) install $(DESTDIR) mlpost $(BUILD)mlpost$(LIBEXT) $(BUILD)mlpost.cmi META $(BCMXA) $(BCMA) $(BCMT)
 
 
 install-byte-dot:
 	$(OCAMLFIND) remove $(DESTDIR) mlpost_dot
 	$(OCAMLFIND) install $(DESTDIR) mlpost_dot contrib/dot/META \
-	   $(addprefix contrib/dot/_build/mlpost_dot,.cmi .cma)
+	   $(addprefix contrib/dot/_build/mlpost_dot,.cmi .cma .cmt .cmti)
 
 install-opt-dot:
 	$(OCAMLFIND) remove $(DESTDIR) mlpost_dot
 	$(OCAMLFIND) install $(DESTDIR) mlpost_dot contrib/dot/META \
-           $(addprefix contrib/dot/_build/mlpost_dot,.cmi .cma .cmxa $(LIBEXT))
+           $(addprefix contrib/dot/_build/mlpost_dot,.cmi .cma .cmxa $(LIBEXT) .cmt .cmti)
 
 ifeq "$(LABLGTK2)$(CAIROLABLGTK2)" "yesyes"
 install-byte-lablgtk:
 	$(OCAMLFIND) remove $(DESTDIR) mlpost_lablgtk
 	$(OCAMLFIND) install $(DESTDIR) mlpost_lablgtk contrib/lablgtk/META \
-	   $(addprefix contrib/lablgtk/_build/mlpost_lablgtk,.cmi .cma)
+	   $(addprefix contrib/lablgtk/_build/mlpost_lablgtk,.cmi .cma .cmt .cmti)
 
 install-opt-lablgtk:
 	$(OCAMLFIND) remove $(DESTDIR) mlpost_lablgtk
 	$(OCAMLFIND) install $(DESTDIR) mlpost_lablgtk contrib/lablgtk/META \
-           $(addprefix contrib/lablgtk/_build/mlpost_lablgtk,.cmi .cma .cmxa $(LIBEXT))
+           $(addprefix contrib/lablgtk/_build/mlpost_lablgtk,.cmi .cma .cmxa $(LIBEXT) .cmt .cmti)
 else
 install-byte-lablgtk:
 

--- a/configure.in
+++ b/configure.in
@@ -57,8 +57,8 @@ else
 fi
 
 case $OCAMLVERSION in
-  3.10.0*)
-    AC_MSG_ERROR(ocamlbuild is too buggy in this version. Aborting.)
+  1.*|2.*|3.*)
+    AC_MSG_ERROR(Mlpost doesn't support OCaml version smaller than 4.0. Aborting.)
     ;;
 esac
 

--- a/configure.in
+++ b/configure.in
@@ -217,22 +217,19 @@ fi
 # libraries
 AC_CHECK_PROG(USEOCAMLFIND,ocamlfind,yes,no)
 
-if test "$USEOCAMLFIND" = yes; then
-   OCAMLFINDLIB=$(ocamlfind printconf stdlib)
-   OCAMLFIND=$(which ocamlfind)
-   if test "$OCAMLFINDLIB" != "$OCAMLLIB"; then
-   USEOCAMLFIND=no;
-   echo "but your ocamlfind is not compatible with your ocamlc:"
+if test "$USEOCAMLFIND" = no; then
+   	AC_MSG_ERROR(Cannot find ocamlfind.)
+fi
+
+OCAMLFINDLIB=$(ocamlfind printconf stdlib)
+OCAMLFIND=$(which ocamlfind)
+if test "$OCAMLFINDLIB" != "$OCAMLLIB"; then
    echo "ocamlfind : $OCAMLFINDLIB, ocamlc : $OCAMLLIB"
-   fi
+   AC_MSG_ERROR(Your ocamlfind is not compatible with your ocamlc.)
 fi
 
 if test "$LIBDIR" = ""; then
-   if test "$USEOCAMLFIND" = yes; then
-        LIBDIR=$(ocamlfind printconf destdir)/mlpost
-   else
-        LIBDIR=$OCAMLLIB/mlpost
-   fi
+   LIBDIR=$(ocamlfind printconf destdir)/mlpost
 fi
 echo "Mlpost library will be installed in: $LIBDIR"
 
@@ -243,23 +240,11 @@ AC_ARG_ENABLE(cairo,
 CAIRO=no
 if test "$enable_cairo" = yes; then
   # checking for mlcairo
-  if test "$USEOCAMLFIND" = yes; then
-     CAIROLIB=$(ocamlfind query cairo)
-  fi
+  CAIROLIB=$(ocamlfind query cairo)
 
   if test -n "$CAIROLIB";then
      echo "ocamlfind found cairo in $CAIROLIB"
      CAIRO=yes
-  else
-      AC_CHECK_FILE($OCAMLLIB/cairo/cairo.cma,CAIRO=yes,CAIRO=no)
-      if test "$CAIRO" = yes; then
-         CAIROLIB=$OCAMLLIB/cairo/
-      elif test -n "$OCAMLLIBLOCAL"; then
-         AC_CHECK_FILE($OCAMLLIBLOCAL/cairo/cairo.cma,CAIRO=yes,CAIRO=no)
-         if test "$CAIRO" = yes; then
-         CAIROLIB=$OCAMLLIBLOCAL/cairo/
-         fi
-      fi
   fi
 fi
 
@@ -269,23 +254,10 @@ AC_ARG_ENABLE(concrete,
 
 BITSTRING=no
 if test "$enable_concrete" = yes; then
-  if test "$USEOCAMLFIND" = yes; then
-     BITSTRINGLIB=$(ocamlfind query bitstring)
-  fi
-
+  BITSTRINGLIB=$(ocamlfind query bitstring)
   if test -n "$BITSTRINGLIB";then
      echo "ocamlfind found bitstring in $BITSTRINGLIB"
      BITSTRING=yes
-  else
-      AC_CHECK_FILE($OCAMLLIB/bitstring/bitstring.cma,BITSTRING=yes,BITSTRING=no)
-      if test "$BITSTRING" = yes; then
-         BITSTRINGLIB=$OCAMLLIB/bitstring/
-      elif test -n "$OCAMLLIBLOCAL"; then
-         AC_CHECK_FILE($OCAMLLIBLOCAL/bitstring/bitstring.cma,BITSTRING=yes,BITSTRING=no)
-         if test "$BITSTRING" = yes; then
-         BITSTRINGLIB=$OCAMLLIBLOCAL/bitstring/
-         fi
-      fi
   fi
 fi
 
@@ -320,22 +292,9 @@ AC_ARG_ENABLE(lablgtk,
 LABLGTK2=no
 if test "$enable_lablgtk" = yes; then
    # checking for lablgtk2
-   if test "$USEOCAMLFIND" == yes; then
       LABLGTK2LIB=$(ocamlfind query lablgtk2)
-   fi
-
    if test -n "$LABLGTK2LIB";then
       echo "ocamlfind found lablgtk2 in $LABLGTK2LIB"
-   else
-    AC_CHECK_FILE($OCAMLLIB/lablgtk2/lablgtk.cma,LABLGTK2=yes,LABLGTK2=no)
-    if test "$LABLGTK2" = yes; then
-       LABLGTK2LIB=$OCAMLLIB/lablgtk2/
-    elif test -n "$OCAMLLIBLOCAL"; then
-       AC_CHECK_FILE($OCAMLLIBLOCAL/lablgtk2/lablgtk2.cma,LABLGTK2=yes,LABLGTK2=no)
-       if test "$LABLGTK2" = yes; then
-       LABLGTK2LIB=$OCAMLLIBLOCAL/lablgtk2/
-       fi
-    fi
    fi
 fi
 
@@ -350,24 +309,10 @@ else
 fi
 
 # checking for cairo.lablgtk2
-if test "$USEOCAMLFIND" == yes; then
-   CAIROLABLGTK2LIB=$(ocamlfind query cairo.lablgtk2)
-fi
+CAIROLABLGTK2LIB=$(ocamlfind query cairo.lablgtk2)
 
 if test -n "$CAIROLABLGTK2LIB";then
    echo "ocamlfind found cairo.lablgtk2 in $CAIROLABLGTK2LIB"
-else
-    AC_CHECK_FILE($OCAMLLIB/cairo/cairo_lablgtk.cma,
-        CAIROLABLGTK2=yes,CAIROLABLGTK2=no)
-    if test "$CAIROLABLGTK2" = yes; then
-        CAIROLABLGTK2LIB=$OCAMLLIB/lablgtk2/
-    elif test -n "$OCAMLLIBLOCAL"; then
-       AC_CHECK_FILE($OCAMLLIBLOCAL/cairo/cairo_lablgtk.cma,
-        CAIROLABLGTK2=yes,CAIROLABLGTK2=no)
-       if test "$CAIROLABLGTK2" = yes; then
-        CAIROLABLGTK2LIB=$OCAMLLIBLOCAL/cairo/
-       fi
-    fi
 fi
 
 if test -n "$LABLGTK2LIB" ; then
@@ -393,7 +338,6 @@ AC_SUBST(OCAMLVERSION)
 AC_SUBST(OCAMLWEB)
 AC_SUBST(OCAMLFIND)
 AC_SUBST(OCAMLBUILD)
-AC_SUBST(USEOCAMLFIND)
 AC_SUBST(LABLGTK2)
 AC_SUBST(INCLUDEGTK2)
 AC_SUBST(LABLGTK2LIB)

--- a/ocamlbuild.Makefile
+++ b/ocamlbuild.Makefile
@@ -29,7 +29,7 @@ else
 OCAMLBUILD_DISPLAY=
 endif
 
-DTYPES = -tag dtypes
+DTYPES = -tag bin_annot
 
 OCAMLBUILD := $(OCAMLBUILDBIN) $(OBOPTS) -no-links $(DTYPES) $(TAGS) $(OCAMLBUILD_DISPLAY) -classic-display -log "build.log"
 
@@ -152,13 +152,13 @@ contrib: dot-contrib lablgtk-contrib
 
 dot-contrib : lib
 	@echo "make: Entering directory \`$(shell pwd)/contrib/dot'"
-	cd contrib/dot && $(OCAMLBUILDBIN) -tag dtypes -cflags -I,$(shell pwd)/_build $(addprefix mlpost_dot,$(LIB_EXT)) && cd ../..
+	cd contrib/dot && $(OCAMLBUILDBIN) $(DTYPES) -cflags -I,$(shell pwd)/_build $(addprefix mlpost_dot,$(LIB_EXT)) && cd ../..
 	ln -sf contrib/dot/_build _build_dot
 
 ifeq "$(LABLGTK2)$(CAIROLABLGTK2)" "yesyes"
 lablgtk-contrib : lib
 	@echo "make: Entering directory \`$(shell pwd)/contrib/lablgtk'"
-	cd contrib/lablgtk && $(OCAMLBUILDBIN) -tag dtypes -cflags -I,$(shell pwd)/_build \
+	cd contrib/lablgtk && $(OCAMLBUILDBIN) $(DTYPES) -cflags -I,$(shell pwd)/_build \
 		-cflags -I,$(LABLGTK2LIB) \
 		-cflags -I,$(CAIROLABLGTK2LIB) \
 		$(addprefix mlpost_lablgtk,$(LIB_EXT)) && cd ../..

--- a/ocamlbuild.Makefile
+++ b/ocamlbuild.Makefile
@@ -155,7 +155,7 @@ dot-contrib : lib
 	cd contrib/dot && $(OCAMLBUILDBIN) -tag dtypes -cflags -I,$(shell pwd)/_build $(addprefix mlpost_dot,$(LIB_EXT)) && cd ../..
 	ln -sf contrib/dot/_build _build_dot
 
-ifeq "$(LABLGTK2)$(CAIROLABLGTK2)$(USEOCAMLFIND)" "yesyesyes"
+ifeq "$(LABLGTK2)$(CAIROLABLGTK2)" "yesyes"
 lablgtk-contrib : lib
 	@echo "make: Entering directory \`$(shell pwd)/contrib/lablgtk'"
 	cd contrib/lablgtk && $(OCAMLBUILDBIN) -tag dtypes -cflags -I,$(shell pwd)/_build \

--- a/opam/descr
+++ b/opam/descr
@@ -1,0 +1,1 @@
+Interface to Metapost

--- a/opam/files/run_autoconf_if_needed.ml
+++ b/opam/files/run_autoconf_if_needed.ml
@@ -1,0 +1,5 @@
+
+
+let () =
+  if not (Sys.file_exists "configure") then
+    exit (Sys.command "autoconf")

--- a/opam/findlib
+++ b/opam/findlib
@@ -1,0 +1,3 @@
+mlpost
+mlpost_dot
+mlpost_lablgtk

--- a/opam/opam
+++ b/opam/opam
@@ -1,0 +1,33 @@
+opam-version: "1"
+maintainer: "filliatr@lri.fr"
+authors: [
+  "Romain Bardou"
+  "Francois Bobot"
+  "Jean-Christophe Filliâtre"
+  "Johannes Kanig"
+  "Stephane Lescuyer"
+]
+license: "GNU Library General Public License version 2.1"
+build: [
+  ["ocaml" "run_autoconf_if_needed.ml"] #when used in pinned mode the configure *can* not yet be generated
+  ["./configure" "--prefix" prefix "--mandir" man]
+  [make]
+  [make "install"]
+  [make "contrib"]
+  [make "install-contrib"]
+]
+remove: [
+  ["ocaml" "run_autoconf_if_needed.ml"] #when used in pinned mode the configure *can* not yet be generated
+  ["./configure" "--prefix" prefix]
+  [make "uninstall"]
+  [make "uninstall-contrib"]
+]
+depends: [
+  "ocamlfind"
+  "bitstring"
+  "cairo" {= "1.2.0"}
+]
+depexts: [
+  [["debian"] ["autoconf"]]
+  [["ubuntu"] ["autoconf"]]
+]


### PR DESCRIPTION
This branch is meant to install .cmt and .cmti files for mlpost (#3). When merlin will support it (if it is not already the case) ocamldoc documentation will be available directly in the editor (merlin only need cmi for completion).

In order to not add conditionals in the Makefile and in order to remove some this branch requires ocaml > 4.0 and ocamlfind. @backtracking @kanigsson, do you agree with these requirement bumps? 