### PR TITLE
remove test for ocamlbuild version

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -175,11 +175,7 @@ else
           AC_MSG_RESULT(ok)
         fi ;;
       *)
-        if test "$TMPVER" != "$OCAMLVERSION" ; then
-          AC_MSG_ERROR(ocamlbuild version differs from ocamlc. Aborting.)
-        else
-          AC_MSG_RESULT(ok)
-        fi ;;
+        AC_MSG_RESULT(ok) ;;
     esac
 fi
 # Then check that we are dealing with ocamlbuild at the right place


### PR DESCRIPTION
In recent versions of OCaml (4.03.0 and later) ocamlbuild is a separate project with its own version numbers, different from OCaml's.