### PR TITLE
Fixes: build & typos

### DIFF
--- a/contrib/graphics/mlpost_graphics.mli
+++ b/contrib/graphics/mlpost_graphics.mli
@@ -110,7 +110,7 @@ module type Graphics =
     used when [set_line_width 1] is specified.
     Raise [Invalid_argument] if the argument is negative. *)
 
-(** {6 Text drawing} *)
+  (** {5 Text drawing} *)
 
     (* val draw_char : char -> unit *)
 (** See {!Graphics.draw_string}.*)
@@ -136,8 +136,7 @@ module type Graphics =
 (** Return the dimensions of the given text, if it were drawn with
     the current font and size. *)
 
-
-(** {6 Filling} *)
+  (** {5 Filling} *)
 
     (* val fill_rect : int -> int -> int -> int -> unit *)
 (** [fill_rect x y w h] fills the rectangle with lower left corner

--- a/garbage/othergraphs.ml
+++ b/garbage/othergraphs.ml
@@ -102,10 +102,12 @@ let d111 =
 let deuxpi = 2.*.3.14159
 
 let d130 =
-  let sq = path ~style:jLine ~scale:N.cm ~cycle:jLine
-    [(0.,0.);(2.,0.);(2.,2.);(0.,2.)] in
-    (** on peut pas utiliser la resolution de MetaPost donc on
-	construit la transform à la main.. :-/ *)
+  let sq =
+    path ~style:jLine ~scale:N.cm ~cycle:jLine
+      [ (0., 0.); (2., 0.); (2., 2.); (0., 2.) ]
+  in
+  (* on peut pas utiliser la resolution de MetaPost donc on
+     construit la transform à la main.. :-/ *)
   let ratio = sqrt (3.28 /. 4.) in
   let angle = atan (0.2 /. 1.8) *. 360. /. deuxpi in
   let v = pt (Num.cm 0.2, Num.cm 0.) in

--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -1,0 +1,43 @@
+module C = Configurator.V1
+
+let mk_default_conf ?cflags ?libs libname =
+  let open C.Pkg_config in 
+  libname, {
+      libs = (match libs with None -> [ "-l"^libname; ] | Some l -> l);
+      cflags = match cflags with None -> [] | Some l -> l;                                                         
+    }
+
+let gen_conf h =
+  let open C.Pkg_config in 
+  Hashtbl.fold (fun _k cf conf ->
+      { libs = cf.libs @ conf.libs;
+        cflags = cf.cflags @ conf.cflags; }
+    )
+    h
+    { libs = []; cflags = []; }
+
+let () =
+  C.main ~name:"foo" (fun c ->
+      let libraries =
+        let h = Hashtbl.create 7 in
+        List.iter (fun (libname, conf) -> Hashtbl.add h libname conf)
+          [ mk_default_conf "freetype2";
+            mk_default_conf "cairo";
+        ];
+        h
+      in
+      
+      let conf =
+        (match C.Pkg_config.get c with
+          | None -> ()
+          | Some pc ->
+             Hashtbl.iter (fun package _ ->
+                 match C.Pkg_config.query pc ~package with
+                 | None -> ()
+                 | Some conf -> Hashtbl.replace libraries package conf 
+               )
+               libraries);
+        gen_conf libraries
+      in
+      C.Flags.write_sexp "c_flags.sexp"         conf.cflags;
+      C.Flags.write_sexp "c_library_flags.sexp" conf.libs)

--- a/src/config/dune
+++ b/src/config/dune
@@ -1,0 +1,3 @@
+(executable
+ (name discover)
+ (libraries dune.configurator))

--- a/src/dune
+++ b/src/dune
@@ -5,9 +5,12 @@
   (libraries unix bitstring cairo2 mlpost_version)
   (preprocess (pps ppx_bitstring img))
   (c_names ml_mlpost_ft)
-  (c_library_flags -lfreetype -lz)
-  (c_flags -I/usr/include/freetype2 -I/usr/include/cairo)
-)
+  (c_library_flags (:include c_library_flags.sexp))
+  (c_flags (:include c_flags.sexp)))
 
 (ocamllex scan_prelude pfb_lexer map_lexer)
 (ocamlyacc pfb_parser map_parser)
+
+(rule
+ (targets c_flags.sexp c_library_flags.sexp)
+ (action  (run ./config/discover.exe)))

--- a/src/gentex.ml
+++ b/src/gentex.ml
@@ -57,15 +57,15 @@ let read_up_to_one =
   let end_ = "[1]" in
   let rec aux buf inc =
     let s =
-        try
-          input_line inc
-        with End_of_file ->
-          Buffer.output_buffer stdout buf;
-          invalid_arg ("One tex snipet contains an error")
-      in
-      Buffer.add_string buf s;
-      Buffer.add_char buf '\n';
-    if ends_with end_ s then () else aux buf inc in
+      try input_line inc
+      with End_of_file ->
+        Buffer.output_buffer stdout buf;
+        invalid_arg "One tex snippet contains an error"
+    in
+    Buffer.add_string buf s;
+    Buffer.add_char buf '\n';
+    if ends_with end_ s then () else aux buf inc
+  in
   fun inc ->
     let buf = Buffer.create 10 in
     aux buf inc

--- a/src/metapost.ml
+++ b/src/metapost.ml
@@ -123,9 +123,10 @@ let mps ?prelude ?(verbose=false) bn figl =
     else []
 
 let call_mptopdf ?inv ?outv ?verbose f =
-  (** assume that f is ps file or sth like that *)
-  ignore (Misc.call_cmd ?inv ?outv ?verbose
-    (sprintf "mptopdf %s" (File.to_string f)));
+  (* assume that f is ps file or sth like that *)
+  ignore
+    (Misc.call_cmd ?inv ?outv ?verbose
+       (sprintf "mptopdf %s" (File.to_string f)));
   let out = File.set_ext f "pdf" in
   File.move (File.append out ("-"^File.extension f)) out;
   out
@@ -146,8 +147,9 @@ let png ?prelude ?verbose bn figl =
 
 let wrap_tempdir f suffix ?prelude ?verbose ?clean bn figl =
   let do_ from_ to_ =
-    (** first copy necessary files, then do your work *)
-    List.iter (fun f -> File.copy (File.place from_ f) (File.place to_ f))
+    (* first copy necessary files, then do your work *)
+    List.iter
+      (fun f -> File.copy (File.place from_ f) (File.place to_ f))
       (Defaults.get_required_files ());
     let l = f ?prelude ?verbose bn figl in
     l, l

--- a/src/mlpost.mli
+++ b/src/mlpost.mli
@@ -1459,13 +1459,21 @@ module Box : sig
         @param same_width if [true], all boxes are of same width,
                and at least of [min_width]; default is false*)
 
-  val vblock : ?padding:Num.t -> ?pos:Command.position -> ?name:string ->
-               ?stroke:Color.t option -> ?pen:Pen.t -> ?dash:Dash.t ->
-               ?min_height:Num.t -> ?same_height:bool -> t list -> t
-    (** similar to [hblock], with vertical alignment. @param
-        min_height minimum height of all boxes; default is zero @param
-        same_height if [true], all boxes are of same height, and at
-        least of [min_height]; default is false*)
+  val vblock :
+    ?padding:Num.t ->
+    ?pos:Command.position ->
+    ?name:string ->
+    ?stroke:Color.t option ->
+    ?pen:Pen.t ->
+    ?dash:Dash.t ->
+    ?min_height:Num.t ->
+    ?same_height:bool ->
+    t list ->
+    t
+  (** similar to [hblock], with vertical alignment.
+      @param min_height minimum height of all boxes; default is zero
+      @param same_height if [true], all boxes are of same height, and at
+      least of [min_height]; default is false*)
 
   val grid :
     ?hpadding:Num.t -> ?vpadding:Num.t -> ?pos:Command.position ->

--- a/src/mps.ml
+++ b/src/mps.ml
@@ -106,8 +106,8 @@ module MPS = struct
   let grestore fmt = fprintf fmt "grestore"
 
   let setlinewidth fmt f =
-    (** strange treatment of linewidth of Metapost *)
-   fprintf fmt "0 %a dtransform truncate idtransform setlinewidth pop" float f
+    (* handle strange treatment of linewidth of Metapost *)
+    fprintf fmt "0 %a dtransform truncate idtransform setlinewidth pop" float f
 
   let setlinecap fmt c =
     let i =
@@ -547,7 +547,7 @@ let draw fmt x =
   fprintf fmt "%%%%BoundingBox: %f %f %f %f\n" minxt minyt maxxt maxyt;
   fprintf fmt "%%%%HiResBoundingBox: %f %f %f %f\n" minx miny maxx maxy;
   fprintf fmt "%%%%Creator: Mlpost %s\n" Mlpost_version.version;
-  (** metapost add a creation date but it breaks determinism *)
+  (* metapost adds a creation date but this breaks determinism *)
   (* fprintf fmt "%%%%CreationDate: %s\n" (Misc.date_string ()); *)
   fprintf fmt "%%%%Pages: 1\n";
   FM.iter (fontdecl fmt) (fonts x);

--- a/src/pgf.ml
+++ b/src/pgf.ml
@@ -94,8 +94,8 @@ module PGF = struct
   let grestore fmt = fprintf fmt "\\end{pgfscope}"
 
   let setlinewidth fmt f =
-    (** strange treatment of linewidth of Metapost *)
-   fprintf fmt "\\pgfsetlinewidth{%a}" bp f
+    (* handle strange treatment of linewidth of Metapost *)
+    fprintf fmt "\\pgfsetlinewidth{%a}" bp f
 
   let setlinecap fmt c =
     let i =


### PR DESCRIPTION
This is a pot-pourri of fixes that occurred when trying to compile on NixOS

The most notable change is the addition of a `discover.ml` file for `dune` to avoid hardcoded path for C libraries.

The rest is mostly typos and various warnings fix