### PR TITLE
Add mlpost_init

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 o - changes in behaviour, new features, bugfixes
 * - incompatible changes in the interface
 
+o add mlpost-init which initialize a directory for compiling mlpost figures using dune
 o fixes floating-point error in extremum computation
 o special points are kept in empty from box
 o migrate to cairo2 and dune

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ doc:
 promote:
 	dune build @promote --auto-promote || true  #For dune.inc
 	dune build @promote --auto-promote || true  #For *.dune.inc
-	dune runtest
+	dune runtest --auto-promote
 
 headers:
 	headache -c headache_config.txt -h header.txt \

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
 (lang dune 2.7)
+(cram enable)

--- a/mlpost.opam
+++ b/mlpost.opam
@@ -25,4 +25,6 @@ depends: [
   "ppx_bitstring"
   "cairo2" { >= "0.6.2" }
   "dune" { >= "2.7.0" }
+  "cmdliner"
+  "fmt"
 ]

--- a/tests/mlpost_init/dune
+++ b/tests/mlpost_init/dune
@@ -1,0 +1,1 @@
+(cram (deps %{bin:mlpost-init}))

--- a/tests/mlpost_init/run.t
+++ b/tests/mlpost_init/run.t
@@ -1,0 +1,38 @@
+  $ mlpost-init foo bar
+
+  $ dune build --root=mlpost_figures @mps
+  Entering directory 'mlpost_figures'
+
+  $ dune build --root=mlpost_figures @pgf
+  Entering directory 'mlpost_figures'
+
+  $ dune build --root=mlpost_figures foo.png bar.png
+  Entering directory 'mlpost_figures'
+
+  $ ls mlpost_figures/
+  _build
+  bar.ml
+  bar.mps
+  bar.pgf
+  bar.png
+  common_for_figures.ml
+  dune
+  dune-project
+  foo.ml
+  foo.mps
+  foo.pgf
+  foo.png
+
+  $ cat >>mlpost_figures/common_for_figures.ml <<EOF
+  > 
+  > let tex = tex ~stroke:(Some Color.blue)
+  > EOF
+
+  $ cp mlpost_figures/foo.pgf mlpost_figures/foo.bak.pgf
+
+  $ dune build --root=mlpost_figures @pgf
+  Entering directory 'mlpost_figures'
+
+  $ cmp mlpost_figures/foo.bak.pgf mlpost_figures/foo.pgf
+  mlpost_figures/foo.bak.pgf mlpost_figures/foo.pgf differ: char 62, line 3
+  [1]

--- a/tools/dune
+++ b/tools/dune
@@ -17,6 +17,15 @@
  (package mlpost)
  (libraries mlpost mlpost_desc_options mlpost_version))
 
+
+(executable
+ (name mlpost_init)
+ (modules Mlpost_init)
+ (public_name mlpost-init)
+ (package mlpost)
+ (libraries cmdliner fmt unix)
+)
+
 ; (executable
 ;   (name gmlpost)
 ;   (public_name gmlpost)

--- a/tools/mlpost_init.ml
+++ b/tools/mlpost_init.ml
@@ -1,0 +1,68 @@
+let writef f file =
+  let cout = open_out file in
+  let fmt = Format.formatter_of_out_channel cout in
+  f fmt;
+  Format.pp_print_flush fmt ();
+  close_out cout
+
+let print_dune_project fmt =
+  Fmt.pf fmt "(lang dune 2.7)"
+
+let print_common_template fmt =
+  Fmt.pf fmt "open! Mlpost@\n";
+  Fmt.pf fmt "open! Box@\n"
+
+
+let print_fig_template name fmt =
+  Fmt.pf fmt "open Mlpost@\n";
+  Fmt.pf fmt "open Box@\n";
+  Fmt.pf fmt "open! Common_for_figures@\n";
+  Fmt.pf fmt "let fig = draw (tex %S)@\n" name;
+  Fmt.pf fmt "let () = Metapost.emit %S fig@\n" name
+
+let modes = ["mps";"pgf";"png"]
+
+let additional_options mode =
+  match mode with
+  | "png" -> ["-cairo"]
+  | _ -> []
+
+let print_dune figures latex fmt =
+  let latex = match latex with None -> "" | Some s -> Fmt.str "-latex %S" s in
+  Fmt.pf fmt "(executables (names %a) (libraries mlpost mlpost.options))@\n@\n" Fmt.(list string) figures;
+  List.iter (fun fig ->
+      List.iter (fun mode ->
+      Fmt.pf fmt "(rule (targets %S) (alias %s) (action (run %S -%s %s %a)) (mode promote-until-clean))"
+        (fig^"."^mode)
+        mode
+        ("./"^fig^".exe")
+        mode
+        latex
+        Fmt.(list string) (additional_options mode)
+        ) modes) figures;
+  ()
+
+let run figures latex outdir =
+  Unix.mkdir outdir 0o770;
+  writef print_dune_project (Filename.concat outdir "dune-project");
+  List.iter
+    (fun fig -> writef
+        (print_fig_template fig)
+        (Filename.concat outdir (fig ^ ".ml")))
+    figures;
+  writef (print_dune figures latex) (Filename.concat outdir "dune");
+  writef print_common_template (Filename.concat outdir "common_for_figures.ml");
+  0
+
+let cmd =
+  let open Cmdliner in
+  let figures = Arg.(value & pos_all string [] &
+                     info [] ~docv:"FIG" ~doc:"mlpost figures to initialize") in
+  let latex = Arg.(value & opt (some string) None &
+                     info ["latex"] ~docv:"TEX" ~doc:"latex file to include") in
+  let outdir = Arg.(value & opt string "mlpost_figures" &
+                     info ["dir"] ~docv:"DIR" ~doc:"directory to initialize") in
+  Term.(const run $ figures $ latex $ outdir)
+
+let () =
+  Cmdliner.Term.(exit_status (eval (cmd,info "mlpost-init")))


### PR DESCRIPTION
Add an experimental tool for initializing a directory for compiling mlpost figures using dune. In a way it replaces the mlpost command. The advantage is that dune handles the .merlin, and rebuild only if needed, and figures can be more easily separated in different files.

They are still some problem with `-latex`.