### PR TITLE
Use ppxlib instead of ocaml-migrate-parsetree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+_opam/
 _build/
 _build_dot
 _build_lablgtk

--- a/customdoc/dune
+++ b/customdoc/dune
@@ -2,7 +2,7 @@
  (name img)
  (modules img)
  (kind ppx_rewriter)
- (libraries ocaml-migrate-parsetree str))
+ (libraries ppxlib str))
 
 (executable
  (name img_doc)

--- a/customdoc/img.ml
+++ b/customdoc/img.ml
@@ -1,48 +1,29 @@
-open Migrate_parsetree
-open OCaml_403.Ast
-open Parsetree
+open Ppxlib
 
-let img_regexp = Str.regexp "^ *@img \\([a-z.]*\\)"
+module B = Ast_builder.Make (struct
+  let loc = Location.none
+end)
 
-let img_subst (s : string) =
-  Str.global_replace img_regexp "{%html:<img alt=\"\\1\" src=\"img/\\1\"/>%}" s
+let img_subst =
+  let img_regexp = Str.regexp "^ *@img \\([a-z.]*\\)" in
+  Str.global_replace img_regexp "{%html:<img alt=\"\\1\" src=\"img/\\1\"/>%}"
 
-let rewriter _config _cookies =
-  let super = Ast_mapper.default_mapper in
-  let attribute _self ((t, p) as a : attribute) =
-    if t.txt = "ocaml.text" || t.txt = "ocaml.doc" then
-      ( t,
-        match p with
-        | PStr
-            [
-              ( {
-                  pstr_desc =
-                    Pstr_eval
-                      ( ( {
-                            pexp_desc = Pexp_constant (Pconst_string (doc, None));
-                            _;
-                          } as pexp ),
-                        [] );
-                  _;
-                } as pstr );
-            ] ->
-            PStr
-              [
-                {
-                  pstr with
-                  pstr_desc =
-                    Pstr_eval
-                      ( {
-                          pexp with
-                          pexp_desc =
-                            Pexp_constant (Pconst_string (img_subst doc, None));
-                        },
-                        [] );
-                };
-              ]
-        | _ -> failwith "not implemented kind of comment" )
-    else a
-  in
-  { super with attribute }
+let rewrite_payload p =
+  Ast_pattern.(parse (pstr (pstr_eval (estring __) __ ^:: nil))) Location.none p
+    (fun s _ -> img_subst s)
+  |> fun s -> PStr B.[ pstr_eval (estring s) [] ]
 
-let () = Driver.register ~name:"ppx1" (module OCaml_403) rewriter
+let rewriter =
+  object
+    inherit Ast_traverse.map
+
+    method! attribute a =
+      if a.attr_name.txt = "ocaml.text" || a.attr_name.txt = "ocaml.doc" then
+        { a with attr_payload = rewrite_payload a.attr_payload }
+      else a
+  end
+
+let () =
+  let intf = rewriter#signature in
+  let impl = rewriter#structure in
+  Driver.register_transformation ~intf ~impl "mlpost_doc"

--- a/mlpost.opam
+++ b/mlpost.opam
@@ -35,7 +35,7 @@ depends: [
   "ppx_bitstring"
   "cairo2" { >= "0.6.2" }
   "dune" { >= "2.7.0" }
-  "ocaml-migrate-parsetree" {< "2.0.0"}
+  "ppxlib" {>= "0.20.0"}
 ]
 depopts: [
   "graphics"


### PR DESCRIPTION
This restores coinstallability with packages that depend on new versions of ppxlib.﻿
