### PR TITLE
fix for recent metapost 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ _mlpost.*
 /mlpost.install
 /mlpost-lablgtk2.install
 /mlpost-lablgtk.install
+out
+out.aux
+out.log
+out.pdf
+out.rubbercache

--- a/src/metapost.ml
+++ b/src/metapost.ml
@@ -26,8 +26,7 @@ let print fmt i c =
 
 let print_prelude s fmt () =
   fprintf fmt
-    "input metafun.mp ; %% some initializations and auxiliary macros\n\
-     %% macros that support special features\n\
+     "%% macros that support special features\n\
      @\n";
   fprintf fmt "prologues := 0;@\n";
   fprintf fmt "mpprocset := 0;@\n";


### PR DESCRIPTION
Hi @backtracking,

After an upgrade of my Debian I was getting these errors (it was working before):

```shell-session
$ mlpost -v figures.ml
+ /home/zapashcanon/.config/opam/4.14.0/bin/ocamlfind ocamlc -w -58 -o /tmp/mlpost1b08ee -package mlpost.options -package mlpost -linkpkg -g -linkall figures.ml
+ /tmp/mlpost1b08ee "-v"  --  
Loading font cmr10 at [655360/655360]...done
Loading font cmtt10 at [655360/655360]...done
Loading font cmr7 at [458752/458752]...done
Loading font cmmi10 at [655360/655360]...done
Loading font cmmi7 at [458752/458752]...done
Loading font cmsy7 at [458752/458752]...done
+ mpost -interaction=nonstopmode mlpost1b08ee.mp
This is MetaPost, version 2.02 (TeX Live 2023/Debian) (kpathsea version 6.3.5)
(/usr/share/texlive/texmf-dist/metapost/base/mpost.mp
(/usr/share/texlive/texmf-dist/metapost/base/plain.mp
Preloading the plain mem file, version 1.005) ) (./mlpost1b08ee.mp
(/usr/share/texmf/metapost/context/base/common/metafun.mp
! I can't open file `metafun.mpii'.
l.6     input metafun.mpii
                          
Please type another input file name
! Emergency stop.
l.6     input metafun.mpii
                          
Transcript written on mlpost1b08ee.log.
Fatal error: exception Unix.Unix_error(Unix.ENOENT, "rename", "mlpost1b08ee.1")
```

I found out that removing this line in `metapost.ml` makes it work again...