### PR TITLE
small fixes

### DIFF
--- a/contrib/dot/dune
+++ b/contrib/dot/dune
@@ -2,7 +2,7 @@
  (name mlpost_dot)
  (public_name mlpost.dot)
  (synopsis "Library for Mlpost which use dot to place Box, Picture, ...")
- (libraries mlpost))
+ (libraries mlpost unix))
 
 (ocamllex xdot_lexer)
 

--- a/dune-project
+++ b/dune-project
@@ -7,7 +7,7 @@
 
 (name mlpost)
 
-(license LGPL-2.1)
+(license LGPL-2.1-only)
 
 (authors
  "Romain Bardou"

--- a/mlpost-lablgtk.opam
+++ b/mlpost-lablgtk.opam
@@ -12,7 +12,7 @@ authors: [
   "Claude Marché"
   "Florence Plateau"
 ]
-license: "LGPL-2.1"
+license: "LGPL-2.1-only"
 tags: [
   "ocaml" "latex" "figure" "mlpost" "metapost" "graphics" "lablgtk" "gtk"
 ]

--- a/mlpost.opam
+++ b/mlpost.opam
@@ -13,7 +13,7 @@ authors: [
   "Claude Marché"
   "Florence Plateau"
 ]
-license: "LGPL-2.1"
+license: "LGPL-2.1-only"
 tags: ["ocaml" "latex" "figure" "mlpost" "metapost" "graphics"]
 homepage: "https://github.com/backtracking/mlpost"
 bug-reports: "https://github.com/backtracking/mlpost/issues"

--- a/tools/dune
+++ b/tools/dune
@@ -12,10 +12,10 @@
 
 (executable
  (name tool)
- (modules Tool)
+ (modules tool)
  (public_name mlpost)
  (package mlpost)
- (libraries mlpost mlpost_desc_options mlpost_version))
+ (libraries mlpost mlpost_desc_options mlpost_version unix))
 
 ; (executable
 ;   (name gmlpost)


### PR DESCRIPTION
Hi,

Two small improvements:

- add `unix` to the `libraries` field when it was missing (it is no longer auto-included and this is producing tons of warnings)
- fix the licence name in `dune-project` to comply with SPDX standard and make opam-lint happy.

I'm not sure if you wanted `LGPL-2.1-only` or `LGPL-2.1-or-later` thus I choosed the conservative one (`-only`), feel free to change it in `dune-project` and to run `dune build @all` to regenerate the opam files.